### PR TITLE
Fix handling of optional argument without '='

### DIFF
--- a/src/main/java/gnu/getopt/Getopt.java
+++ b/src/main/java/gnu/getopt/Getopt.java
@@ -951,6 +951,11 @@ checkLongOption()
               return('?');
             }
         } // if (nameend)
+      else if (pfound.has_arg == LongOpt.OPTIONAL_ARGUMENT && optind < argv.length)
+        {
+           optarg = argv[optind];
+           ++optind;
+        }
       else if (pfound.has_arg == LongOpt.REQUIRED_ARGUMENT)
         {
           if (optind < argv.length)


### PR DESCRIPTION
Using the GetoptDemo:

Before the fix:

```
$ java -cp build:build/resources:. GetoptDemo --maximum=3
I know this, but pretend I didn't
We picked option maximum with value 3
$ java -cp build:build/resources:. GetoptDemo --maximum 3
I know this, but pretend I didn't
We picked option maximum with value null
I see you have return in order set and that a non-option argv element was just found with the value '3'
```
